### PR TITLE
groupId of parent in pom files have the wrong name

### DIFF
--- a/security/code/auth-service/pom.xml
+++ b/security/code/auth-service/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>service-discovery</groupId>
+        <groupId>security</groupId>
         <artifactId>root</artifactId>
         <version>0.0.1-SNAPSHOT</version>
 

--- a/security/code/bookmark-service/pom.xml
+++ b/security/code/bookmark-service/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>service-discovery</groupId>
+        <groupId>security</groupId>
         <artifactId>root</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.0.3.RELEASE</version>
+            <version>2.0.4.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>

--- a/security/code/eureka/pom.xml
+++ b/security/code/eureka/pom.xml
@@ -5,7 +5,7 @@
 
 
     <parent>
-        <groupId>service-discovery</groupId>
+        <groupId>security</groupId>
         <artifactId>root</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/security/code/passport-service/pom.xml
+++ b/security/code/passport-service/pom.xml
@@ -5,7 +5,7 @@
 
 
     <parent>
-        <groupId>service-discovery</groupId>
+        <groupId>security</groupId>
         <artifactId>root</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/security/code/photo-service/pom.xml
+++ b/security/code/photo-service/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>service-discovery</groupId>
+        <groupId>security</groupId>
         <artifactId>root</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.0.3.RELEASE</version>
+            <version>2.0.4.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>


### PR DESCRIPTION
The parent:groupId of the modules needs to be changed from service-discovery to security. It seems that it was a cut and paste issue. service-discovery is an unrelated project.
